### PR TITLE
FIX repeatscout directory argument

### DIFF
--- a/configure
+++ b/configure
@@ -257,7 +257,7 @@ my $repMaskLocation = $config->{'REPEATMASKER_DIR'}->{'value'};
 if ( !$options{'recon_dir'} ) {
   RepModelConfig::promptForParam( 'RECON_DIR' );
 }
-if ( !$options{'repeatscout_dir'} ) {
+if ( !$options{'rscout_dir'} ) {
   RepModelConfig::promptForParam( 'RSCOUT_DIR' );
 }
 if ( !$options{'dustmasker_prgm'} ) {


### PR DESCRIPTION
Currently, the directory of repeatscout cannot be passed to `configure` as
it erroneously checks for an argument `repeatscout_dir`.
Argument name should be `rscout_dir` according to `README.md`.
